### PR TITLE
Identify if driver supports foreign keys

### DIFF
--- a/lib/baza/base_sql_driver.rb
+++ b/lib/baza/base_sql_driver.rb
@@ -15,6 +15,10 @@ class Baza::BaseSqlDriver
     @sep_index = "`"
   end
 
+  def foreign_key_support?
+    true
+  end
+
   def escape(string)
     string.to_s.gsub(/([\0\n\r\032\'\"\\])/) do
       case Regexp.last_match(1)

--- a/lib/baza/driver/sqlite3.rb
+++ b/lib/baza/driver/sqlite3.rb
@@ -42,6 +42,18 @@ class Baza::Driver::Sqlite3 < Baza::BaseSqlDriver
     end
   end
 
+  def enable_foreign_key_support
+    return true if @foreign_key_support_enabled
+
+    @db.query("PRAGMA foreign_keys = ON")
+    @foreign_key_support_enabled = true
+    true
+  end
+
+  def foreign_key_support?
+    false
+  end
+
   # Executes a query against the driver.
   def query(sql)
     @mutex_statement_reader.synchronize do


### PR DESCRIPTION
Disabled in SQLite3 because it was very difficult to implement